### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/examples/ds1307_simpletest.py
+++ b/examples/ds1307_simpletest.py
@@ -24,7 +24,6 @@ rtc = adafruit_ds1307.DS1307(i2c_bus)
 days = ("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
 
 
-# pylint: disable-msg=bad-whitespace
 # pylint: disable-msg=using-constant-test
 if False:  # change to True if you want to set the time!
     #                     year, mon, date, hour, min, sec, wday, yday, isdst
@@ -35,7 +34,6 @@ if False:  # change to True if you want to set the time!
     rtc.datetime = t
     print()
 # pylint: enable-msg=using-constant-test
-# pylint: enable-msg=bad-whitespace
 
 # Main loop:
 while True:


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.