### PR TITLE
adafruit_ds1307 module does not respect user-changed values for Square Wave output

### DIFF
--- a/adafruit_ds1307.py
+++ b/adafruit_ds1307.py
@@ -97,7 +97,8 @@ class DS1307:
     def __init__(self, i2c_bus):
         self.i2c_device = I2CDevice(i2c_bus, 0x68)
 
-        # Try and verify this is the RTC we expect by checking the rate select fields described as "0 = Always reads back as 0."
+        # Try and verify this is the RTC we expect by checking constant fields.
+        # These fields are described as "0 = Always reads back as 0." in spec.
         buf = bytearray(2)
         buf[0] = 0x07
         with self.i2c_device as i2c:


### PR DESCRIPTION
I am working on a project with my rp2040 where I am using my DS1307 to trigger an interrupt every 1 second.
I had started this project in MicroPython with another library, and had updated register 07 in the DS1307 with the flags to generate a 1Hz square wave. ( set bits in register to '00010000' ).

When I started updating my project to use CircuitPython, I imported this library and found that it used those bits to validate if it is a 1307, which will not work.

This pull request is to update the module to reflect the specifications provided by the manufacture for which fields are constant.