### PR TITLE
Fix day-of-week string indexing to obey Python definition

### DIFF
--- a/examples/ds1307_simpletest.py
+++ b/examples/ds1307_simpletest.py
@@ -14,7 +14,7 @@ i2c = board.I2C()
 rtc = adafruit_ds1307.DS1307(i2c)
 
 # Lookup table for names of days (nicer printing).
-days = ("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
+days = ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
 
 
 # pylint: disable-msg=using-constant-test


### PR DESCRIPTION
Python defines "time.struct_time.tm_wday" (the day-of-week element) as
"range [0, 6], Monday is 0"; see:
https://docs.python.org/3/library/time.html#time.struct_time

When expanding the day-of-week integer to a string, the code incorrectly
used Sunday-as-0; probably a cut&paste error brought over from C code.